### PR TITLE
Fix atomic swap transaction

### DIFF
--- a/clove/network/bitcoin.py
+++ b/clove/network/bitcoin.py
@@ -8,7 +8,7 @@ import struct
 from Crypto import Random
 from Crypto.Cipher import AES
 from bitcoin import SelectParams
-from bitcoin.core import COIN, CMutableTransaction, CMutableTxIn, CMutableTxOut, COutPoint, Hash160, b2x, lx, script
+from bitcoin.core import COIN, CMutableTransaction, CMutableTxIn, CMutableTxOut, COutPoint, b2x, lx, script
 from bitcoin.core.key import CPubKey
 from bitcoin.core.scripteval import SCRIPT_VERIFY_P2SH, VerifyScript
 from bitcoin.wallet import CBitcoinAddress, CBitcoinSecret, P2PKHBitcoinAddress
@@ -94,14 +94,14 @@ class BitcoinTransaction(object):
             script.OP_EQUALVERIFY,
             script.OP_DUP,
             script.OP_HASH160,
-            Hash160(self.recipient_address.encode()),
+            CBitcoinAddress(self.recipient_address),
             script.OP_ELSE,
             str(int(self.locktime.timestamp())).encode(),
             script.OP_CHECKLOCKTIMEVERIFY,
             script.OP_DROP,
             script.OP_DUP,
             script.OP_HASH160,
-            Hash160(self.sender_address.encode()),
+            CBitcoinAddress(self.sender_address),
             script.OP_ENDIF,
             script.OP_EQUALVERIFY,
             script.OP_CHECKSIG,
@@ -125,7 +125,7 @@ class BitcoinTransaction(object):
     def generate_hash(self):
         wallet = BitcoinWallet()
         self.secret = wallet.secret
-        self.secret_hash = wallet.private_key
+        self.secret_hash = sha256(self.secret).digest()
 
     def build_outputs(self):
         self.generate_hash()

--- a/clove/utils/hashing.py
+++ b/clove/utils/hashing.py
@@ -1,0 +1,12 @@
+from hashlib import sha256
+from random import choices
+from string import ascii_letters, digits
+
+
+def generate_secret_with_hash() -> (bytes, bytes):
+    secret = ''.join(choices(ascii_letters + digits, k=64))
+    secret = bytes(secret.encode('utf-8'))
+
+    secret_hash = sha256(secret).digest()
+
+    return secret,  secret_hash

--- a/tests/test_bitcoin_transfer.py
+++ b/tests/test_bitcoin_transfer.py
@@ -46,7 +46,6 @@ def test_show_details(alice_wallet, bob_wallet, alice_outpoints):
 
     str_fields = (
         'contract',
-        'contract_address',
         'contract_transaction',
         'contract_transaction_hash',
         'recipient_address',

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,10 @@
+from hashlib import sha256
+
+from clove.utils.hashing import generate_secret_with_hash
+
+
+def test_generate_secret_with_hash():
+    secret, secret_hash = generate_secret_with_hash()
+    assert isinstance(secret, bytes)
+    assert isinstance(secret_hash, bytes)
+    assert sha256(secret).digest() == secret_hash


### PR DESCRIPTION
Use `self.contract` in the output transaction and multiply `change` by `COIN`
Use `CBitcoinAddress` in contract to get hashed public key in `CScript`.
Hash `secret` with `sha256` to match condition in contract.
Extract generating secret with hash.