### PR TITLE
INTERNAL: test script update (excluding spent transactions)

### DIFF
--- a/bin/test-initial-transaction
+++ b/bin/test-initial-transaction
@@ -32,7 +32,7 @@ def get_utxo(address, amount):
             for txs in data['txs']:
                 for i, output in enumerate(txs['outputs']):
                     if not output['addresses'] or output['addresses'][0] != address \
-                            or output['script_type'] != 'pay-to-pubkey-hash':
+                            or output['script_type'] != 'pay-to-pubkey-hash' or 'spent_by' in output:
                         continue
                     value = satoshi_to_btc(output['value'])
                     utxo.append(
@@ -46,7 +46,7 @@ def get_utxo(address, amount):
                     total += value
                     if total > amount:
                         return utxo
-            return utxo
+            exit(f'>>> Cannot find enough UTXO\'s. {total:.8f} is all that you\'ve got.')
     except (URLError, HTTPError):
         print('>>> Cannot get UTXO\'s from API')
         return

--- a/clove/network/bitcoin.py
+++ b/clove/network/bitcoin.py
@@ -176,7 +176,7 @@ class BitcoinTransaction(object):
             )
 
     def create_unsigned_transaction(self):
-        assert self.utxo_value >= self.value
+        assert self.utxo_value >= self.value, 'You want to spend more than you\'ve got. Add more UTXO\'s.'
         self.build_outputs()
         self.tx = CMutableTransaction(self.tx_in_list, self.tx_out_list, nLockTime=self.tx_locktime)
 


### PR DESCRIPTION
```
╰(clove)─λ bin/test-initial-transaction
How many BTC do you want to transfer? 0.7
>>> Creating transaction for BitcoinTestNet
>>> Sender address:	 msJ2ucZ2NDhpVzsiNE5mGUFzqFDggjBVTM
>>> Recipient address:	 mmJtKA92Mxqfi3XdyGReza69GjhkwAcBN1
>>> Transaction amount:	 0.7
>>> Searching for UTXO's
>>> Cannot find enough UTXO's. 0.60789871 is all that you've got.
```

```
╰(clove)─λ bin/test-initial-transaction
How many BTC do you want to transfer? 0.6
>>> Creating transaction for BitcoinTestNet
>>> Sender address:	 msJ2ucZ2NDhpVzsiNE5mGUFzqFDggjBVTM
>>> Recipient address:	 mmJtKA92Mxqfi3XdyGReza69GjhkwAcBN1
>>> Transaction amount:	 0.6
>>> Searching for UTXO's
>>> Found 2 UTXO's
[Utxo(tx_id='f474dde225a2513865871a9614c476289c06c6a4ddda2a5374f05c657d6afc90', vout='1', value='0.58758054', tx_script='76a914812ff3e5afea281eb3dd7fce9b077e4ec6fba08b88ac', wallet=None, secret=None, refund=False),
 Utxo(tx_id='05fc88a672811b28ad513d2fed1381bcb91de368e5ba5e2337660c6b711d8e73', vout='1', value='0.02031817', tx_script='76a914812ff3e5afea281eb3dd7fce9b077e4ec6fba08b88ac', wallet=None, secret=None, refund=False)]
>>> Adding fee and signing
>>> Transaction ready to be published
{'contract': '63a82094e04ff45d2608104be0f0b4ce020d58f8143f08f28d708c718b5e141eb883fa8876a9143f8870a5633e4fdac612fba47525fef082bbe9616704a93c805ab17576a914812ff3e5afea281eb3dd7fce9b077e4ec6fba08b6888ac',
 'contract_transaction': '010000000290fc6a7d655cf074532adadda4c6069c2876c414961a87653851a225e2dd74f4010000006a4730440220654135ed2664f5043a336aa9c452e20b70ef0d5a9cd5b212be91d4c89f6855f9022019100ae5c21a5d579e165280b266cabe78b0d15c0548203cb3d7c55a177d0acd012103142762372a0f6f2b4718cdee32fa1a3cc2465d3379312e8875ee5f919315817700000000738e1d716b0c6637235ebae568e31db9bc8113ed2f3d51ad281b8172a688fc05010000006a47304402203b1bb3e4d731b0c452b3098cfa3525a087b5f0417cda977037f2d46511d0745f02203e885d258c57ab5c111b271922b5e948b729a7e317d7f0ea5fc4f55716473112012103142762372a0f6f2b4718cdee32fa1a3cc2465d3379312e8875ee5f9193158177000000000200879303000000005d63a82094e04ff45d2608104be0f0b4ce020d58f8143f08f28d708c718b5e141eb883fa8876a9143f8870a5633e4fdac612fba47525fef082bbe9616704a93c805ab17576a914812ff3e5afea281eb3dd7fce9b077e4ec6fba08b6888ac198a0900000000001976a914812ff3e5afea281eb3dd7fce9b077e4ec6fba08b88ac00000000',
 'fee': 0.00164694,
 'fee_per_kb': 0.00347456,
 'fee_per_kb_text': '0.00347456 BTC / 1 kB',
 'fee_text': '0.00164694 BTC',
 'locktime': datetime.datetime(2018, 2, 11, 13, 52, 57, 930614),
 'recipient_address': 'mmJtKA92Mxqfi3XdyGReza69GjhkwAcBN1',
 'refund_address': 'msJ2ucZ2NDhpVzsiNE5mGUFzqFDggjBVTM',
 'secret': '4f746b61434f34756c534f464238756a556f354c71384a386970424e787868544c7a53524f7963776a303965506f6f6c42593058336b4634414b4e675453736c',
 'secret_hash': '94e04ff45d2608104be0f0b4ce020d58f8143f08f28d708c718b5e141eb883fa',
 'size': 473,
 'size_text': '473 bytes',
 'transaction_hash': '15fef8c08b68e6f52b760fbdb1e6d1f2a8e13a9ae74c1620540328be8c6f3467',
 'value': 0.6,
 'value_text': '0.60000000 BTC'}
Do you want to publish this transaction (y/n): n
>>> Bye!
```