### PR TITLE
[#134] Auditing Bitcoin-based transaction with transaction_address

### DIFF
--- a/clove/network/bitcoin/base.py
+++ b/clove/network/bitcoin/base.py
@@ -407,8 +407,13 @@ class BitcoinBaseNetwork(BaseNetwork):
         return transaction
 
     @auto_switch_params()
-    def audit_contract(self, contract: str, raw_transaction: str) -> BitcoinContract:
-        return BitcoinContract(self, contract, raw_transaction)
+    def audit_contract(
+        self,
+        contract: str,
+        raw_transaction: Optional[str]=None,
+        transaction_address: Optional[str]=None,
+    ) -> BitcoinContract:
+        return BitcoinContract(self, contract, raw_transaction, transaction_address)
 
     @classmethod
     @auto_switch_params()

--- a/clove/network/bitcoin/transaction.py
+++ b/clove/network/bitcoin/transaction.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import struct
 
 from bitcoin.core import CMutableTransaction, CMutableTxOut, b2lx, b2x, script, x
@@ -186,7 +186,7 @@ class BitcoinAtomicSwapTransaction(BitcoinTransaction):
             script.OP_HASH160,
             CBitcoinAddress(self.recipient_address),
             script.OP_ELSE,
-            int(self.locktime.timestamp()),
+            int(self.locktime.replace(tzinfo=timezone.utc).timestamp()),
             script.OP_CHECKLOCKTIMEVERIFY,
             script.OP_DROP,
             script.OP_DUP,

--- a/clove/utils/bitcoin.py
+++ b/clove/utils/bitcoin.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from bitcoin.core import COIN, CTransaction, x
 
 from clove.exceptions import ImpossibleDeserialization
@@ -20,6 +22,7 @@ def deserialize_raw_transaction(raw_transaction: str) -> CTransaction:
 
 def auto_switch_params(args_index: int = 0):
     def wrap(f):
+        @wraps(f)
         def wrapped(*args, **kwargs):
             if 'network' in kwargs:
                 kwargs['network'].switch_params()

--- a/clove/utils/external_source.py
+++ b/clove/utils/external_source.py
@@ -36,8 +36,8 @@ def clove_req_json(url: str):
 def get_transaction(network: str, tx_hash: str, testnet: bool=False) -> Optional[dict]:
 
     symbol = network.lower()
-    if symbol not in NETWORKS_WITH_API:
-        raise ValueError('This network has not API.')
+    if symbol not in NETWORKS_WITH_API and symbol != 'RVN':
+        raise ValueError('This network has no API.')
 
     if symbol in BLOCKCYPHER_SUPPORTED_NETWORKS:
         if testnet and symbol != 'btc':
@@ -46,7 +46,10 @@ def get_transaction(network: str, tx_hash: str, testnet: bool=False) -> Optional
         api_url = f'https://api.blockcypher.com/v1/{symbol}/{network_url}/txs/{tx_hash}?limit=50&includeHex=true'
         return clove_req_json(api_url)
 
-    return clove_req(f'https://chainz.cryptoid.info/{symbol}/api.dws?q=txinfo&t={tx_hash}')
+    if symbol == 'RVN':
+        return clove_req_json(f'http://explorer.threeeyed.info/api/getrawtransaction?txid={tx_hash}&decrypt=1')
+
+    return clove_req_json(f'https://chainz.cryptoid.info/{symbol}/api.dws?q=txinfo&t={tx_hash}')
 
 
 def get_last_transactions(network: str) -> Optional[list]:

--- a/tests/test_bitcoin_transfer.py
+++ b/tests/test_bitcoin_transfer.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from bitcoin.core import CTransaction, b2x, script
 from freezegun import freeze_time
 from pytest import raises
 
 from clove.constants import SIGNATURE_SIZE
-from clove.network.bitcoin import BitcoinTestNet
+from clove.network import BitcoinTestNet, Litecoin
 from clove.network.bitcoin.transaction import BitcoinAtomicSwapTransaction, BitcoinTransaction
 from clove.utils.bitcoin import to_base_units
 
@@ -195,6 +196,49 @@ def test_audit_contract_non_matching_contract(signed_transaction):
         ValueError, match='Given transaction is not a valid contract.'
     ):
         btc_network.audit_contract(contract, transaction_details['contract_transaction'])
+
+
+def test_audit_contract_by_address_blockcypher():
+    ltc_network = Litecoin()
+    contract = ltc_network.audit_contract(
+        contract=(
+            '63a6140d33bfb2b425ca1d91a9a90af9472d6b7a6760d88876a914621f617c765c3caa5ce1bb67f6a'
+            '3e51382b8da296704ab0ece5ab17576a91485c0522f6e23beb11cc3d066cd20ed732648a4e66888ac'
+        ),
+        transaction_address='2d08cb8a4c06c5df7d21334a0dff5aaebf55d1b3adb8545d707f2b45888f932b'
+    )
+    assert contract.show_details() == {
+        'contract_address': 'MAyEizEWZEQdd4Ghp7Es3ssN77d7yLbqZQ',
+        'locktime': datetime(2018, 4, 11, 13, 33, 31),
+        'recipient_address': 'LUAn5PWmsPavgz32mGkqsUuAKncftS37Jq',
+        'refund_address': 'LXRAXRgPo84p58746zaBXUFFevCTYBPxgb',
+        'secret_hash': '0d33bfb2b425ca1d91a9a90af9472d6b7a6760d8',
+        'transaction_address': '2d08cb8a4c06c5df7d21334a0dff5aaebf55d1b3adb8545d707f2b45888f932b',
+        'value': 0.001,
+        'value_text': '0.00100000 LTC',
+     }
+
+
+@patch('clove.utils.external_source.BLOCKCYPHER_SUPPORTED_NETWORKS', return_value=('xxx', ))
+def test_audit_contract_by_address_cryptoid(_):
+    ltc_network = Litecoin()
+    contract = ltc_network.audit_contract(
+        contract=(
+            '63a6140d33bfb2b425ca1d91a9a90af9472d6b7a6760d88876a914621f617c765c3caa5ce1bb67f6a'
+            '3e51382b8da296704ab0ece5ab17576a91485c0522f6e23beb11cc3d066cd20ed732648a4e66888ac'
+        ),
+        transaction_address='2d08cb8a4c06c5df7d21334a0dff5aaebf55d1b3adb8545d707f2b45888f932b'
+    )
+    assert contract.show_details() == {
+        'contract_address': 'MAyEizEWZEQdd4Ghp7Es3ssN77d7yLbqZQ',
+        'locktime': datetime(2018, 4, 11, 13, 33, 31),
+        'recipient_address': 'LUAn5PWmsPavgz32mGkqsUuAKncftS37Jq',
+        'refund_address': 'LXRAXRgPo84p58746zaBXUFFevCTYBPxgb',
+        'secret_hash': '0d33bfb2b425ca1d91a9a90af9472d6b7a6760d8',
+        'transaction_address': '2d08cb8a4c06c5df7d21334a0dff5aaebf55d1b3adb8545d707f2b45888f932b',
+        'value': 0.001,
+        'value_text': '0.00100000 LTC',
+     }
 
 
 def test_redeem_transaction(bob_wallet, signed_transaction):


### PR DESCRIPTION
```
In [1]: from clove.network import Litecoin

In [2]: n = Litecoin()

In [3]: c = n.audit_contract(contract='63a6140d33bfb2b425ca1d91a9a90af9472d6b7a6760d88876a914621f617c765c3caa5ce1bb67f6a3e51382b8da296704ab0ece5ab17576a91485c0522f6e23beb11cc3d066cd20ed732648a4e66888ac', transaction_address='2d08cb8a4c06c5df7d21334a0dff5aaebf55d1b3adb8545d707f2b45888f932b')

In [4]: c.show_details()
Out[4]: 
{'contract_address': 'MAyEizEWZEQdd4Ghp7Es3ssN77d7yLbqZQ',
 'locktime': datetime.datetime(2018, 4, 11, 15, 33, 31),
 'recipient_address': 'LUAn5PWmsPavgz32mGkqsUuAKncftS37Jq',
 'refund_address': 'LXRAXRgPo84p58746zaBXUFFevCTYBPxgb',
 'secret_hash': '0d33bfb2b425ca1d91a9a90af9472d6b7a6760d8',
 'transaction_address': '2d08cb8a4c06c5df7d21334a0dff5aaebf55d1b3adb8545d707f2b45888f932b',
 'value': 0.001,
 'value_text': '0.00100000 LTC'}
```